### PR TITLE
Add option to request only recent listens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Can also only request a few pages:
 listenbrainz_export export seanbreckenridge --pages 3
 ```
 
+Or can request only recent listens:
+
+```
+listenbrainz_export export seanbreckenridge --days 30
+```
+
+
 [`listenbrainz_export.parse`](./listenbrainz_export/parse.py) includes a model of the data and some functions to parse them into python objects, like:
 
 ```python

--- a/listenbrainz_export/__main__.py
+++ b/listenbrainz_export/__main__.py
@@ -30,12 +30,18 @@ def playing_now(listenbrainz_username: str) -> None:
     default=None,
     help="Request these many pages of your history",
 )
+@click.option(
+    "--days",
+    type=int,
+    default=None,
+    help="Request listens no older than this many days",
+)
 @click.argument("LISTENBRAINZ_USERNAME")
-def export(pages: Optional[int], listenbrainz_username: str) -> None:
+def export(pages: Optional[int], days: Optional[int], listenbrainz_username: str) -> None:
     """
     Downloads all scrobbles for your listenbrainz account
     """
-    click.echo(json.dumps(request_listens(username=listenbrainz_username, pages=pages)))
+    click.echo(json.dumps(request_listens(username=listenbrainz_username, pages=pages, days=days)))
 
 
 if __name__ == "__main__":

--- a/listenbrainz_export/export.py
+++ b/listenbrainz_export/export.py
@@ -85,8 +85,8 @@ def request_listens(
             f"Have {len(all_listens)}, now searching for listens before {datetime.utcfromtimestamp(max_ts)}..."
         )
         curpage += 1
-        if ((pages is not None and curpage >= pages)
-            or (days is not None
-                and (datetime.utcfromtimestamp(max_ts) < datetime.utcnow() - timedelta(days=days)))):
+        if pages is not None and curpage >= pages:
+            break
+        if days is not None and (datetime.utcfromtimestamp(max_ts) < datetime.utcnow() - timedelta(days=days)):
             break
     return all_listens

--- a/listenbrainz_export/export.py
+++ b/listenbrainz_export/export.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional, List, Dict, Any
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 import backoff  # type: ignore[import]
@@ -67,7 +67,10 @@ def request_chunk(
 
 
 def request_listens(
-    username: str, logger: logging.Logger = logzero.logger, pages: Optional[int] = None
+        username: str,
+        logger: logging.Logger = logzero.logger,
+        pages: Optional[int] = None,
+        days: Optional[int] = None
 ) -> Json:
     max_ts: Optional[int] = None
     all_listens: List[Json] = []
@@ -82,6 +85,8 @@ def request_listens(
             f"Have {len(all_listens)}, now searching for listens before {datetime.utcfromtimestamp(max_ts)}..."
         )
         curpage += 1
-        if pages is not None and curpage >= pages:
+        if ((pages is not None and curpage >= pages)
+            or (days is not None
+                and (datetime.utcfromtimestamp(max_ts) < datetime.utcnow() - timedelta(days=days)))):
             break
     return all_listens


### PR DESCRIPTION
My listens history goes back to 2005, so it's rather large, and therefore slow to update. Using the `--pages` option to limit it to recent listens isn't helpful, because I might listen to a variable number of songs between updates.

This PR implements a `--days` option that stops the exporter after seeing a listen older than the specified number of days. This means the last page of the export will contain listens older than the specified number of days, but this I think is no problem.